### PR TITLE
fix(qn-platform): Correct Tailwind CSS content paths

### DIFF
--- a/apps/qn-platform/tailwind.config.ts
+++ b/apps/qn-platform/tailwind.config.ts
@@ -3,9 +3,7 @@ import type { Config } from "tailwindcss";
 export default {
 	darkMode: "class",
 	content: [
-	content: [
 		"./src/**/*.{js,ts,jsx,tsx,mdx}",
-	],
 	],
 	prefix: "",
 	theme: {


### PR DESCRIPTION
The styling for the qn-platform application was not being applied correctly because the `content` paths in `tailwind.config.ts` were misconfigured. The paths were not correctly pointing to the source files within the `src` directory, causing Tailwind CSS to not detect the used classes and therefore not generate the required styles.

This commit corrects the paths in the `content` array to ensure that Tailwind CSS scans the correct files for class names. This resolves the issue of the missing styles.